### PR TITLE
create cachepath directory with necessary parents

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,7 +13,7 @@ func Load() (cachePath string){
   cachePath = cacheDir + "/manw/"
 
   if _, err := os.Stat(cachePath); os.IsNotExist(err) {
-    err := os.Mkdir(cachePath, 0700)
+    err := os.MkdirAll(cachePath, 0700)
     utils.CheckError(err)
   }
 


### PR DESCRIPTION
Use `os.MkdirAll` to create the cache directory along with any necessary parents.

Running manw on a linux system without an existing `$HOME/.cache` directory would fail:

```
$ manw createfilew
2020/11/12 10:41:12 mkdir /home/user/.cache/manw/: no such file or directory
```